### PR TITLE
Remove GPU option

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,24 @@
+* Copyright (c) 2020 FIRST
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*     * Redistributions of source code must retain the above copyright
+*       notice, this list of conditions and the following disclaimer.
+*     * Redistributions in binary form must reproduce the above copyright
+*       notice, this list of conditions and the following disclaimer in the
+*       documentation and/or other materials provided with the distribution.
+*     * Neither the name of FIRST nor the
+*       names of its contributors may be used to endorse or promote products
+*       derived from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY FIRST AND CONTRIBUTORS "AS IS" AND ANY
+* EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY NONINFRINGEMENT AND FITNESS FOR A PARTICULAR
+* PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL FIRST OR CONTRIBUTORS BE LIABLE FOR
+* ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/training.ipynb
+++ b/training.ipynb
@@ -40,21 +40,10 @@
     "from sagemaker.estimator import Estimator\n",
     "from sagemaker import get_execution_role\n",
     "\n",
-    "\n",
-    "# Uses GPU by default, change to false to use CPU\n",
-    "use_gpu = True\n",
-    "\n",
     "role = get_execution_role()\n",
     "\n",
-    "instance_type = None\n",
-    "algorithm_name = None\n",
-    "\n",
-    "if use_gpu:\n",
-    "    instance_type = 'ml.p3.2xlarge'\n",
-    "    algorithm_name = 'wpi-gpu'\n",
-    "else:\n",
-    "    instance_type = 'ml.c4.2xlarge'\n",
-    "    algorithm_name = 'wpi-cpu'\n",
+    "instance_type = 'ml.c4.2xlarge'\n",
+    "algorithm_name = 'wpi-cpu'\n",
     "\n",
     "\n",
     "\"\"\"\n",
@@ -110,10 +99,10 @@
   "pycharm": {
    "stem_cell": {
     "cell_type": "raw",
+    "source": [],
     "metadata": {
      "collapsed": false
-    },
-    "source": []
+    }
    }
   }
  },


### PR DESCRIPTION
AWS Educate will not support training on GPUs, so no reason to give teams the option.